### PR TITLE
Add transaction details in currency exchange

### DIFF
--- a/home/index.html
+++ b/home/index.html
@@ -208,7 +208,7 @@
 								</div>
 								<input type="number" class="form-control" id="exchangeAmount" />
 							</div>
-							<p>Subtotal: $<span id="exchangeAction"></span></p>
+							<p>Recibirás: US$<span id="usdAmount"></span></p>
 							<p>Impuesto PAIS (30%): $<span id="exchangeTax"></span></p>
 							<p>Total: $<span id="exchangeTotal"></span></p>
 						</form>

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -99,7 +99,7 @@ const exchangeMoney = async e => {
 	let activeUser = JSON.parse(sessionStorage.getItem("activeUser"));
 	const { dni } = activeUser;
 	let body = {
-		amount: document.getElementById("exchangeAmount").value,
+		amount: document.getElementById("exchangeTotal").textContent,
 		originAccountNum: findAccountData(activeUser, "$").accountNumber,
 		destinationAccountNum: findAccountData(activeUser, "US$").accountNumber,
 		userID: dni,
@@ -119,13 +119,38 @@ const exchangeMoney = async e => {
 		sessionStorage.setItem("activeUser", JSON.stringify(jsonResponse));
 		applyShadowBox("danger", "ars");
 		applyShadowBox("success", "usd");
+		document.getElementById("exchangeAmount").value = "";
 		renderData();
 	} else {
 		console.log(jsonResponse); /// TODO: Aca hay que mostrar un modal en el front diciendo que alguno de los datos son incorrectos.
 	}
 };
 
+const showTransactionDetails = () => {
+	const arsAmount = document.getElementById("exchangeAmount").value;
+	const exchangeRate = document.getElementById("exchangeRate");
+	const usdAmount = document.getElementById("usdAmount");
+	const exchangeTax = document.getElementById("exchangeTax");
+	const totalAmount = document.getElementById("exchangeTotal");
+
+	getExangeRate().then(response => (exchangeRate.textContent = response.US$));
+	exchangeTax.textContent = +arsAmount * 0.3;
+	usdAmount.textContent = (+arsAmount / exchangeRate.textContent).toFixed(2);
+	totalAmount.textContent = +arsAmount + +exchangeTax.textContent;
+};
+
+const getExangeRate = async () => {
+	const response = await fetch(
+		"http://127.0.0.1:3000/v1/accounts/operations/getexangerate",
+	);
+	const jsonResponse = await response.json();
+	return jsonResponse;
+};
+
 // Selectores
 document.getElementById("btn-internTransf").addEventListener("click", addMoney);
 document.getElementById("btn-externTransf").addEventListener("click", transferExternal);
 document.getElementById("btn-exchangeMoney").addEventListener("click", exchangeMoney);
+document
+	.getElementById("exchangeAmount")
+	.addEventListener("input", showTransactionDetails);

--- a/server/main.js
+++ b/server/main.js
@@ -137,6 +137,7 @@ server.put(
 		// Obtiene indice de cuentas
 		const destinationAccountIndex = getAccountIndex(activeUser, +destinationAccountNum);
 		const originAccountIndex = getAccountIndex(activeUser, +originAccountNum);
+
 		if (
 			validateExistingAccounts(
 				activeUser,
@@ -150,8 +151,9 @@ server.put(
 				// Realiza conversión de moneda
 				const originCurrency = activeUser.accounts[originAccountIndex].currency;
 				const destinationCurrency = activeUser.accounts[destinationAccountIndex].currency;
+				const netAmount = +amount / 1.3;
 				const transformedAmount = applyCurrencyExange(
-					+amount,
+					+netAmount,
 					originCurrency,
 					destinationCurrency,
 				);


### PR DESCRIPTION
* Se agrego funcion en el front que muestra el preview de la transaccion de compra de USD a medida que el usuario ingresa el monto en pesos (incluye impuesto PAIS).
* Se ajustó el back para que reciba el monto en pesos total (incluyendo impuesto PAIS) y netee dicho impuesto previo a hacer la conversion. De esta manera en la cuenta pesos se netea el monto total pero en la cuenta USD se acreditan sobre el monto neto de impuestos.